### PR TITLE
feat (mcp): Adding http support to the mcp server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
     },
     "explorer.experimental.fileNesting.enabled": true,
     "explorer.fileNesting.patterns": {
-    "*.go": "*.http"
+    ".go": ".http"
 }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,14 @@
 {
     "dotnet.defaultSolution": "disable",
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "rest-client.enableTelemetry": false,
+    "rest-client.environmentVariables": {
+        "local": {
+          "host": "http://localhost:8181"
+        }
+    },
+    "explorer.experimental.fileNesting.enabled": true,
+    "explorer.fileNesting.patterns": {
+    "*.go": "*.http"
+}
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Make sure an entry exists in this file for the deploy path of the local exe:
 {
   "mcpServers": {
 	"mcp-cocktails-go": {
-      "command": "D:\\Github\\cezzis-com-cocktails-mcp\\cocktails.mcp\\dist\\cezzis-cocktails.exe"
+      "command": "D:\\Github\\cezzis-com-cocktails-mcp\\cocktails.mcp\\dist\\cezzis-cocktails.exe",
+      "args": ["--stdio"]
     }
   }
 }
@@ -61,7 +62,8 @@ Or open the mcp settings within cursor via `Ctrl Shift P` > `View: Open Mcp Sett
 {
   "mcpServers": {
 	"mcp-cocktails-go": {
-      "command": "D:\\Github\\cezzis-com-cocktails-mcp\\cocktails.mcp\\dist\\cezzis-cocktails.exe"
+      "command": "D:\\Github\\cezzis-com-cocktails-mcp\\cocktails.mcp\\dist\\cezzis-cocktails.exe",
+      "args": ["--stdio"]
     }
   }
 }

--- a/cocktails.mcp/src/cmd/main.go
+++ b/cocktails.mcp/src/cmd/main.go
@@ -1,15 +1,22 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"log"
+	"net/http"
 
 	"github.com/mark3labs/mcp-go/server"
 
 	"cezzis.com/cezzis-mcp-server/pkg/tools"
 )
 
-// main initializes and runs the Cezzi Cocktails MCP server, registering cocktail search and retrieval tools and serving requests over standard input/output.
+// main initializes and runs the Cezzi Cocktails MCP server, registering cocktail search and retrieval tools and serving requests over standard input/output or HTTP.
 func main() {
+	// Add a flag to choose between stdio and HTTP
+	httpAddr := flag.String("http", "", "If set, serve HTTP on this address (e.g., :8080). Otherwise, use stdio.")
+	flag.Parse()
+
 	mcpServer := server.NewMCPServer(
 		"Cezzi Cocktails Server",
 		"1.0.0",
@@ -19,8 +26,38 @@ func main() {
 	mcpServer.AddTool(tools.CocktailSearchTool, server.ToolHandlerFunc(tools.CocktailSearchToolHandler))
 	mcpServer.AddTool(tools.CocktailGetTool, server.ToolHandlerFunc(tools.CocktailGetToolHandler))
 
-	// Start the stdio server
-	if err := server.ServeStdio(mcpServer); err != nil {
-		fmt.Printf("Server error: %v\n", err)
+	// Logging middleware for HTTP
+	logMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Wrap the ResponseWriter to capture status code
+			type statusRecorder struct {
+				http.ResponseWriter
+				status int
+			}
+			rec := &statusRecorder{ResponseWriter: w, status: 200}
+			next.ServeHTTP(rec, r)
+			log.Printf("%s %s %s %d", r.Method, r.URL.Path, r.RemoteAddr, rec.status)
+		})
+	}
+
+	if *httpAddr != "" {
+		// HTTP mode
+		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"ok"}`))
+		})
+
+		// Use the official streamable HTTP server for MCP
+		streamableHTTP := server.NewStreamableHTTPServer(mcpServer)
+		http.Handle("/mcp", logMiddleware(streamableHTTP))
+		http.Handle("/healthz", logMiddleware(http.DefaultServeMux))
+		log.Printf("Serving HTTP on %s", *httpAddr)
+		log.Fatal(http.ListenAndServe(*httpAddr, nil))
+	} else {
+		// Stdio mode (default)
+		if err := server.ServeStdio(mcpServer); err != nil {
+			fmt.Printf("Server error: %v\n", err)
+		}
 	}
 }

--- a/cocktails.mcp/src/cmd/main.go
+++ b/cocktails.mcp/src/cmd/main.go
@@ -51,7 +51,7 @@ func main() {
 		// Use the official streamable HTTP server for MCP
 		streamableHTTP := server.NewStreamableHTTPServer(mcpServer)
 		http.Handle("/mcp", logMiddleware(streamableHTTP))
-		http.Handle("/healthz", logMiddleware(http.DefaultServeMux))
+		//http.Handle("/healthz", logMiddleware(http.DefaultServeMux))
 		log.Printf("Serving HTTP on %s", *httpAddr)
 		log.Fatal(http.ListenAndServe(*httpAddr, nil))
 	} else {

--- a/cocktails.mcp/src/pkg/tools/cocktailGetTool.go.http
+++ b/cocktails.mcp/src/pkg/tools/cocktailGetTool.go.http
@@ -46,9 +46,9 @@ Mcp-Session-Id: mcp-session-24f4d503-d725-4aa3-bae0-d4ded79b4a6e
   "id": "1",
   "method": "tools/call",
   "params": {
-    "name": "cocktails_search",
+    "name": "cocktails_get",
     "arguments": {
-      "freeText": "martini"
+      "cocktailId": "pimms-cup"
     }
   }
 }

--- a/cocktails.mcp/src/pkg/tools/cocktailSearchTool.go.http
+++ b/cocktails.mcp/src/pkg/tools/cocktailSearchTool.go.http
@@ -1,0 +1,54 @@
+
+// ------------------------------------------------------------
+// Haeanthz
+// ------------------------------------------------------------
+
+GET {{host}}/healthz
+Accept: application/json
+
+###
+
+// ------------------------------------------------------------
+// Initialize Request
+// ------------------------------------------------------------
+
+POST {{host}}/mcp
+Accept: application/json
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "cocktails-dot-http-file",
+      "version": "1.0.0"
+    }
+  }
+}
+
+// ------------------------------------------------------------
+// Cocktail FreeText Search
+// ------------------------------------------------------------
+
+POST {{host}}/mcp
+Accept: application/json
+Content-Type: application/json
+Mcp-Session-Id: mcp-session-24f4d503-d725-4aa3-bae0-d4ded79b4a6e
+
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "callTool",
+  "params": {
+    "tool": "cocktails_search",
+    "input": {
+      "freeText": "martini"
+    }
+  }
+}
+
+###

--- a/makefile
+++ b/makefile
@@ -9,6 +9,9 @@ copyenv:
 run:
 	./cocktails.mcp/dist/cezzis-cocktails.exe
 
+run-http:
+	./cocktails.mcp/dist/cezzis-cocktails.exe --http :8181
+
 clean:
 	rm -rf ./cocktails.mcp/dist/ && mkdir ./cocktails.mcp/dist
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running the server over HTTP with a new command-line flag to specify the listen address.
  * Introduced a `/healthz` endpoint for health checks.
  * Implemented logging of HTTP requests, including method, path, remote address, and status code.
  * Provided HTTP request definitions for cocktail search and cocktail retrieval to facilitate API testing.

* **Bug Fixes**
  * Updated authentication middleware to disable authentication gracefully when configuration is missing, allowing all requests to proceed.

* **Chores**
  * Enhanced server startup and error logging for HTTP mode.
  * Updated README with additional configuration examples for MCP server setup.
  * Improved development environment with new VSCode settings for REST Client and file nesting.
  * Added a makefile target to run the server in HTTP mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->