### PR TITLE
feat (oauth): Changing to public client app registration

### DIFF
--- a/terraform/b2c_tenant/mcp_app_registration.tf
+++ b/terraform/b2c_tenant/mcp_app_registration.tf
@@ -1,7 +1,6 @@
 resource "azuread_application" "cocktails_mcp_app_registration" {
-  display_name                   = "appr-${var.sub}-${var.region}-${var.environment}-${var.domain}mcp-${var.sequence}"
-  sign_in_audience               = "AzureADandPersonalMicrosoftAccount"
-  fallback_public_client_enabled = true
+  display_name     = "appr-${var.sub}-${var.region}-${var.environment}-${var.domain}mcp-${var.sequence}"
+  sign_in_audience = "AzureADandPersonalMicrosoftAccount"
   # identifier_uris removed - not needed for client apps
 
   # api block is needed for requested_access_token_version
@@ -9,15 +8,10 @@ resource "azuread_application" "cocktails_mcp_app_registration" {
     requested_access_token_version = 2
   }
 
-  web {
+  public_client {
     redirect_uris = [
       "http://localhost:6097/callback",
     ]
-
-    implicit_grant {
-      access_token_issuance_enabled = true
-      id_token_issuance_enabled     = true
-    }
   }
 
   lifecycle {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration to use a public client instead of a web client for the app registration.
  * Removed legacy implicit grant settings and the fallback public client flag.
  * Kept existing redirect URIs and API permissions unchanged.
  * Minor formatting cleanups with no behavioral impact.
  * No user-facing changes expected; sign-in should continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->