### PR TITLE
Add SafeSkill security badge (91/100 — Verified Safe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Docs](https://img.shields.io/badge/docs-MCP-blue)](https://modelcontextprotocol.io)
 [![Project](https://img.shields.io/badge/project-Cezzis.com%20Cocktails-181717?logo=github&logoColor=white)](https://github.com/users/mtnvencenzo/projects/2)
 [![Website](https://img.shields.io/badge/website-cezzis.com-2ea44f?logo=google-chrome&logoColor=white)](https://www.cezzis.com)
+[![SafeSkill 91/100](https://img.shields.io/badge/SafeSkill-91%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/mtnvencenzo-cezzis-com-cocktails-mcp)
 
 An MCP (Model Context Protocol) server that gives AI agents secure, first‑class access to Cezzis.com cocktail data. It provides high‑level tools for searching cocktails, retrieving detailed recipes and metadata, authenticating users, and submitting ratings. The server runs over HTTP only and exposes a streamable MCP endpoint.
 


### PR DESCRIPTION
## ✅ SafeSkill Security Scan Results

| Metric | Value |
|:-------|:------|
| **Overall Score** | **91/100** (Verified Safe) |
| Code Score | 99/100 |
| Content Score | 76/100 |
| Findings | 4 findings detected |
| Taint Flows | 0 |
| Files Scanned | 0 |
| Scan Duration | 0.1s |

### Top Findings

- 🟡 **medium**: Missing or invalid package.json (`package.json:0`)
- 🟡 **medium**: Indirect injection vector detected (raw-content-url): "https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/HEAD/configuration-s" (`cocktails.mcp/src/internal/api/accountsapi/accounts_api.yaml:1`)
- 🟡 **medium**: Indirect injection vector detected (raw-content-url): "https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/HEAD/configuration-s" (`cocktails.mcp/src/internal/api/aisearch/aisearch_api.yaml:1`)
- 🟡 **medium**: Indirect injection vector detected (raw-content-url): "https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/HEAD/configuration-s" (`cocktails.mcp/src/internal/api/cocktailsapi/cocktails_api.yaml:1`)

[View full report on SafeSkill](https://safeskill.dev/scan/mtnvencenzo-cezzis-com-cocktails-mcp)

---

### About SafeSkill

[SafeSkill](https://safeskill.dev) is a **free, open-source** security scanner for AI tools, MCP servers, and Claude Code skills. We scan for code exploits, prompt injection, and data exfiltration risks.

**False positive?** We take accuracy seriously. If any finding above is incorrect, please [open an issue](https://github.com/OyadotAI/safeskill/issues/new?title=False+positive+in+mtnvencenzo%2Fcezzis-com-cocktails-mcp&labels=false-positive) and we will fix it immediately.

- [GitHub](https://github.com/OyadotAI/safeskill) | [Website](https://safeskill.dev) | [Docs](https://safeskill.dev/docs)
- Built by [Oya.ai](https://oya.ai) -- AI Employees Builder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SafeSkill verification status badge to the README, indicating project security verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->